### PR TITLE
Add support for optional amounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Supported elements:
     ACCOUNT  AMOUNT [; NOTE]
   ```
 
-  Note that the ``AMOUNT`` field is always required.
+  There may be a single posting without an amount in a transaction.
 
 * Commodity prices with format:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,25 +101,25 @@ P 2017-11-12 12:00:00 mBH 5.00 PLN
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
-                                amount: Amount {
+                                amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
                                         name: "$".to_string(),
                                         position: CommodityPosition::Left
                                     }
-                                },
+                                }),
                                 status: None,
                                 comment: Some("Posting comment line 1\nPosting comment line 2".to_string())
                             },
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
-                                amount: Amount {
+                                amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
                                         name: "$".to_string(),
                                         position: CommodityPosition::Left
                                     }
-                                },
+                                }),
                                 status: None,
                                 comment: None
                             }
@@ -135,25 +135,25 @@ P 2017-11-12 12:00:00 mBH 5.00 PLN
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
-                                amount: Amount {
+                                amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
                                         name: "$".to_string(),
                                         position: CommodityPosition::Left
                                     }
-                                },
+                                }),
                                 status: None,
                                 comment: None
                             },
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
-                                amount: Amount {
+                                amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
                                         name: "$".to_string(),
                                         position: CommodityPosition::Left
                                     }
-                                },
+                                }),
                                 status: None,
                                 comment: None
                             }

--- a/src/model.rs
+++ b/src/model.rs
@@ -92,14 +92,17 @@ impl fmt::Display for TransactionStatus {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Posting {
     pub account: String,
-    pub amount: Amount,
+    pub amount: Option<Amount>,
     pub status: Option<TransactionStatus>,
     pub comment: Option<String>,
 }
 
 impl fmt::Display for Posting {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}  {}", self.account, self.amount)?;
+        write!(f, "{}", self.account)?;
+        if let Some(ref amount) = self.amount {
+            write!(f, "  {}", amount)?;
+        }
 
         if let Some(ref comment) = self.comment {
             for comment in comment.split("\n") {
@@ -213,13 +216,13 @@ mod tests {
                 "{}",
                 Posting {
                     account: "Assets:Checking".to_string(),
-                    amount: Amount {
+                    amount: Some(Amount {
                         quantity: Decimal::new(4200, 2),
                         commodity: Commodity {
                             name: "USD".to_string(),
                             position: CommodityPosition::Left,
                         }
-                    },
+                    }),
                     status: None,
                     comment: Some("asdf".to_string()),
                 }
@@ -242,25 +245,25 @@ mod tests {
                 postings: vec![
                     Posting {
                         account: "TEST:ABC 123".to_string(),
-                        amount: Amount {
+                        amount: Some(Amount {
                             quantity: Decimal::new(120, 2),
                             commodity: Commodity {
                                 name: "$".to_string(),
                                 position: CommodityPosition::Left
                             }
-                        },
+                        }),
                         status: None,
                         comment: Some("dd".to_string())
                     },
                     Posting {
                         account: "TEST:ABC 123".to_string(),
-                        amount: Amount {
+                        amount: Some(Amount {
                             quantity: Decimal::new(120, 2),
                             commodity: Commodity {
                                 name: "$".to_string(),
                                 position: CommodityPosition::Left
                             }
-                        },
+                        }),
                         status: None,
                         comment: None
                     }
@@ -312,25 +315,25 @@ mod tests {
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
-                                amount: Amount {
+                                amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
                                         name: "$".to_string(),
                                         position: CommodityPosition::Left
                                     }
-                                },
+                                }),
                                 status: None,
                                 comment: Some("dd".to_string())
                             },
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
-                                amount: Amount {
+                                amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
                                         name: "$".to_string(),
                                         position: CommodityPosition::Left
                                     }
-                                },
+                                }),
                                 status: None,
                                 comment: None
                             }
@@ -346,25 +349,25 @@ mod tests {
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
-                                amount: Amount {
+                                amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
                                         name: "$".to_string(),
                                         position: CommodityPosition::Left
                                     }
-                                },
+                                }),
                                 status: None,
                                 comment: None
                             },
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
-                                amount: Amount {
+                                amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
                                         name: "$".to_string(),
                                         position: CommodityPosition::Left
                                     }
-                                },
+                                }),
                                 status: None,
                                 comment: None
                             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,12 +17,8 @@ fn is_digit(c: char) -> bool {
     (c >= '0' && c <= '9')
 }
 
-fn is_commodity_first_char(c: char) -> bool {
-    (c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '$' || c > 0x7F as char)
-}
-
 fn is_commodity_char(c: char) -> bool {
-    (c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '$' || c > 0x7F as char)
+    !(('0' <= c && c <= '9') || c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '-')
 }
 
 fn is_white_char(c: char) -> bool {
@@ -167,12 +163,7 @@ named!(string_between_quotes<CompleteStr, &str>,
 
 named!(commodity_without_quotes<CompleteStr, &str>,
     map!(
-        recognize!(
-            tuple!(
-                take_while_m_n!(1, 1, is_commodity_first_char),
-                take_while!(is_commodity_char)
-            )
-        ),
+        take_while1!(is_commodity_char),
         |s: CompleteStr| { s.0 }
     )
 );
@@ -498,6 +489,18 @@ mod tests {
         assert_eq!(
             parse_commodity(CompleteStr("$1")),
             Ok((CompleteStr("1"), "$"))
+        );
+        assert_eq!(
+            parse_commodity(CompleteStr("€1")),
+            Ok((CompleteStr("1"), "€"))
+        );
+        assert_eq!(
+            parse_commodity(CompleteStr("€ ")),
+            Ok((CompleteStr(" "), "€"))
+        );
+        assert_eq!(
+            parse_commodity(CompleteStr("€-1")),
+            Ok((CompleteStr("-1"), "€"))
         );
     }
 


### PR DESCRIPTION
This is a breaking change. This pull request adds support for optional amounts. The parser validates that at most one posting in a transaction has its amount elided. This changes the type of `Posting.amount` to `Option<Amount>`. 