### PR TITLE
Virtual postings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Support for parsing (but ignoring) 'include' directives.
+- Support for virtual postings.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for parsing (but ignoring) 'include' directives.
+
 ### Changed
 
 - Transitioned to Rust 2021 edition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
--
+### Changed
+
+- Transitioned to Rust 2021 edition.
 
 ## [3.1.0] - 2020-04-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 documentation = "https://docs.rs/ledger-parser"
 keywords = ["parser", "ledger", "ledger-cli"]
 categories = ["parser-implementations"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 nom = "4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ impl fmt::Display for ParseError {
 impl std::error::Error for ParseError {
     fn description(&self) -> &str {
         match *self {
-            ParseError::String(ref err) => &err,
+            ParseError::String(ref err) => err,
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -40,7 +40,7 @@ impl fmt::Display for Transaction {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TransactionStatus {
     Pending,
     Cleared,
@@ -56,10 +56,18 @@ impl fmt::Display for TransactionStatus {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Posting {
     pub account: String,
+    pub reality: Reality,
     pub amount: Option<Amount>,
     pub balance: Option<Balance>,
     pub status: Option<TransactionStatus>,
     pub comment: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Reality {
+    Real,
+    BalancedVirtual,
+    UnbalancedVirtual,
 }
 
 impl fmt::Display for Posting {
@@ -94,7 +102,7 @@ pub struct Commodity {
     pub position: CommodityPosition,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CommodityPosition {
     Left,
     Right,
@@ -217,6 +225,7 @@ mod tests {
                 "{}",
                 Posting {
                     account: "Assets:Checking".to_string(),
+                    reality: Reality::Real,
                     amount: Some(Amount {
                         quantity: Decimal::new(4200, 2),
                         commodity: Commodity {
@@ -253,6 +262,7 @@ mod tests {
                 postings: vec![
                     Posting {
                         account: "TEST:ABC 123".to_string(),
+                        reality: Reality::Real,
                         amount: Some(Amount {
                             quantity: Decimal::new(120, 2),
                             commodity: Commodity {
@@ -266,6 +276,7 @@ mod tests {
                     },
                     Posting {
                         account: "TEST:ABC 123".to_string(),
+                        reality: Reality::Real,
                         amount: Some(Amount {
                             quantity: Decimal::new(120, 2),
                             commodity: Commodity {
@@ -305,6 +316,7 @@ mod tests {
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
+                                reality: Reality::Real,
                                 amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
@@ -318,6 +330,7 @@ mod tests {
                             },
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
+                                reality: Reality::Real,
                                 amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
@@ -341,6 +354,7 @@ mod tests {
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
+                                reality: Reality::Real,
                                 amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
@@ -354,6 +368,7 @@ mod tests {
                             },
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
+                                reality: Reality::Real,
                                 amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,7 @@
+use crate::serializer::*;
 use chrono::{NaiveDate, NaiveDateTime};
 use rust_decimal::Decimal;
 use std::fmt;
-use crate::serializer::*;
 
 ///
 /// Main document. Contains transactions and/or commodity prices.

--- a/src/model_internal.rs
+++ b/src/model_internal.rs
@@ -53,7 +53,7 @@ impl From<LedgerInternal> for Ledger {
                 }
                 LedgerItem::LineComment(comment) => {
                     if let Some(ref mut c) = current_comment {
-                        c.push_str("\n");
+                        c.push('\n');
                         c.push_str(&comment);
                     } else {
                         current_comment = Some(comment);
@@ -63,8 +63,8 @@ impl From<LedgerInternal> for Ledger {
                     if let Some(current_comment) = current_comment {
                         let mut full_comment = current_comment;
                         if let Some(ref transaction_comment) = transaction.comment {
-                            full_comment.push_str("\n");
-                            full_comment.push_str(&transaction_comment);
+                            full_comment.push('\n');
+                            full_comment.push_str(transaction_comment);
                         }
                         transaction.comment = Some(full_comment);
                     }
@@ -80,8 +80,8 @@ impl From<LedgerInternal> for Ledger {
         }
 
         Ledger {
-            transactions: transactions,
-            commodity_prices: commodity_prices,
+            transactions,
+            commodity_prices,
         }
     }
 }

--- a/src/model_internal.rs
+++ b/src/model_internal.rs
@@ -111,6 +111,7 @@ mod tests {
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
+                                reality: Reality::Real,
                                 amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
@@ -124,6 +125,7 @@ mod tests {
                             },
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
+                                reality: Reality::Real,
                                 amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
@@ -148,6 +150,7 @@ mod tests {
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
+                                reality: Reality::Real,
                                 amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {
@@ -161,6 +164,7 @@ mod tests {
                             },
                             Posting {
                                 account: "TEST:ABC 123".to_string(),
+                                reality: Reality::Real,
                                 amount: Some(Amount {
                                     quantity: Decimal::new(120, 2),
                                     commodity: Commodity {

--- a/src/model_internal.rs
+++ b/src/model_internal.rs
@@ -25,6 +25,7 @@ pub enum LedgerItem {
     LineComment(String),
     Transaction(Transaction),
     CommodityPrice(CommodityPrice),
+    Include(String),
 }
 
 impl fmt::Display for LedgerItem {
@@ -34,6 +35,7 @@ impl fmt::Display for LedgerItem {
             LedgerItem::LineComment(comment) => writeln!(f, "; {}", comment)?,
             LedgerItem::Transaction(transaction) => writeln!(f, "{}", transaction)?,
             LedgerItem::CommodityPrice(commodity_price) => writeln!(f, "{}", commodity_price)?,
+            LedgerItem::Include(file) => writeln!(f, "include {}", file)?,
         }
         Ok(())
     }
@@ -76,6 +78,7 @@ impl From<LedgerInternal> for Ledger {
                     current_comment = None;
                     commodity_prices.push(commodity_price);
                 }
+                LedgerItem::Include(_file) => {}
             }
         }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,9 +1,10 @@
-use std::io;
 use crate::model::*;
+use std::io;
 
 pub trait Serializer {
     fn write<W>(&self, writer: &mut W, settings: &SerializerSettings) -> Result<(), io::Error>
-        where W: io::Write;
+    where
+        W: io::Write;
 
     fn to_string_pretty(&self, settings: &SerializerSettings) -> String {
         let mut res = Vec::new();
@@ -22,14 +23,22 @@ impl SerializerSettings {
 
     pub fn with_indent(indent: &str) -> Self {
         SerializerSettings {
-            indent: indent.to_string()
+            indent: indent.to_string(),
         }
+    }
+}
+
+impl Default for SerializerSettings {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl Serializer for Ledger {
     fn write<W>(&self, writer: &mut W, settings: &SerializerSettings) -> Result<(), io::Error>
-        where W: io::Write {
+    where
+        W: io::Write,
+    {
         let mut first = true;
 
         for commodity_price in &self.commodity_prices {
@@ -54,7 +63,9 @@ impl Serializer for Ledger {
 
 impl Serializer for Transaction {
     fn write<W>(&self, writer: &mut W, settings: &SerializerSettings) -> Result<(), io::Error>
-        where W: io::Write {
+    where
+        W: io::Write,
+    {
         write!(writer, "{}", self.date)?;
 
         if let Some(effective_date) = self.effective_date {
@@ -75,7 +86,7 @@ impl Serializer for Transaction {
         }
 
         if let Some(ref comment) = self.comment {
-            for comment in comment.split("\n") {
+            for comment in comment.split('\n') {
                 write!(writer, "\n{}; {}", settings.indent, comment)?;
             }
         }
@@ -91,7 +102,9 @@ impl Serializer for Transaction {
 
 impl Serializer for TransactionStatus {
     fn write<W>(&self, writer: &mut W, _settings: &SerializerSettings) -> Result<(), io::Error>
-        where W: io::Write {
+    where
+        W: io::Write,
+    {
         match self {
             TransactionStatus::Pending => write!(writer, "!"),
             TransactionStatus::Cleared => write!(writer, "*"),
@@ -101,7 +114,9 @@ impl Serializer for TransactionStatus {
 
 impl Serializer for Posting {
     fn write<W>(&self, writer: &mut W, settings: &SerializerSettings) -> Result<(), io::Error>
-        where W: io::Write {
+    where
+        W: io::Write,
+    {
         if let Some(ref status) = self.status {
             status.write(writer, settings)?;
             write!(writer, " ")?;
@@ -120,7 +135,7 @@ impl Serializer for Posting {
         }
 
         if let Some(ref comment) = self.comment {
-            for comment in comment.split("\n") {
+            for comment in comment.split('\n') {
                 write!(writer, "\n{}; {}", settings.indent, comment)?;
             }
         }
@@ -131,7 +146,9 @@ impl Serializer for Posting {
 
 impl Serializer for Amount {
     fn write<W>(&self, writer: &mut W, _settings: &SerializerSettings) -> Result<(), io::Error>
-        where W: io::Write {
+    where
+        W: io::Write,
+    {
         match self.commodity.position {
             CommodityPosition::Left => write!(writer, "{}{}", self.commodity.name, self.quantity),
             CommodityPosition::Right => write!(writer, "{} {}", self.quantity, self.commodity.name),
@@ -141,7 +158,9 @@ impl Serializer for Amount {
 
 impl Serializer for Balance {
     fn write<W>(&self, writer: &mut W, settings: &SerializerSettings) -> Result<(), io::Error>
-        where W: io::Write {
+    where
+        W: io::Write,
+    {
         match self {
             Balance::Zero => write!(writer, "0"),
             Balance::Amount(ref balance) => balance.write(writer, settings),
@@ -151,12 +170,10 @@ impl Serializer for Balance {
 
 impl Serializer for CommodityPrice {
     fn write<W>(&self, writer: &mut W, settings: &SerializerSettings) -> Result<(), io::Error>
-        where W: io::Write {
-        write!(
-            writer,
-            "P {} {} ",
-            self.datetime, self.commodity_name
-        )?;
+    where
+        W: io::Write,
+    {
+        write!(writer, "P {} {} ", self.datetime, self.commodity_name)?;
         self.amount.write(writer, settings)?;
         Ok(())
     }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -122,7 +122,11 @@ impl Serializer for Posting {
             write!(writer, " ")?;
         }
 
-        write!(writer, "{}", self.account)?;
+        match self.reality {
+            Reality::Real => write!(writer, "{}", self.account)?,
+            Reality::BalancedVirtual => write!(writer, "[{}]", self.account)?,
+            Reality::UnbalancedVirtual => write!(writer, "({})", self.account)?,
+        }
 
         if let Some(ref amount) = self.amount {
             write!(writer, "{}", settings.indent)?;


### PR DESCRIPTION
Add support for parsing [virtual postings](https://www.ledger-cli.org/3.0/doc/ledger3.html#Virtual-postings) by adding a new `enum Reality` to `ledger_parser::Posting`.

Also did a few other minor things in separate commits, hope you approve:
- Updated Rust edition to 2021 (no code changes required)
- Fixed some minor formatting and lint issues
- Made the parser ignore 'include' directives (I use one to include my budgeting rules from a separate file)