### PR TITLE
Update to nom v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["parser-implementations"]
 edition = "2021"
 
 [dependencies]
-nom = "4"
+nom = "7"
 chrono = "0.4"
 rust_decimal = "1"

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Supported elements:
 
 - Inline comments (starting with `;`)
 
-- Transaction headers with format:
+- Transaction headers with format (minimum two spaces or one tab between `DESC` and `NOTE`):
 
   ```ledger-cli
-  DATE[=EDATE] [*|!] [(CODE)] DESC
+  DATE[=EDATE] [*|!] [(CODE)] DESC  [; NOTE]
   ```
 
 - Transaction postings with format (minimum two spaces or one tab between `ACCOUNT` and `AMOUNT`):

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Supported elements:
   ```
 
   - Virtual accounts are supported
-  - There may be only a single posting without an amount or balance in a transaction
 
 - Commodity prices with format:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@
 //!
 //! - Inline comments (starting with ``;``)
 //!
-//! - Transaction headers with format:
+//! - Transaction headers with format (minimum two spaces or one tab between `DESC` and `NOTE`):
 //!
 //!   ```ledger-cli,ignore
-//!   DATE[=EDATE] [*|!] [(CODE)] DESC
+//!   DATE[=EDATE] [*|!] [(CODE)] DESC  [; NOTE]
 //!   ```
 //!
 //! - Transaction postings with format (minimum two spaces or one tab between ``ACCOUNT`` and ``AMOUNT``):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 //!   ```
 //!
 //!     - Virtual accounts are supported
-//!     - There may be only a single posting without an amount or balance in a transaction
 //!
 //! - Commodity prices with format:
 //!
@@ -38,6 +37,7 @@ pub use serializer::*;
 
 mod parser;
 
+use nom::{error::convert_error, Finish};
 use std::fmt;
 
 #[derive(Debug)]
@@ -65,7 +65,7 @@ impl std::error::Error for ParseError {
 ///
 /// # Examples
 ///
-/// ```rust,ignore
+/// ```
 /// let result = ledger_parser::parse(r#"; Example 1
 /// 2018-10-01=2018-10-14 ! (123) Description
 ///   ; Transaction comment
@@ -74,12 +74,9 @@ impl std::error::Error for ParseError {
 ///   TEST:Account 345  -$1.20"#);
 /// ```
 pub fn parse(input: &str) -> Result<Ledger, ParseError> {
-    use nom::types::CompleteStr;
-
-    let result = parser::parse_ledger(CompleteStr(input));
-    match result {
-        Ok((CompleteStr(""), result)) => Ok(result),
-        Ok((rest, _)) => Err(ParseError::String(rest.0.to_string())),
-        Err(error) => Err(ParseError::String(format!("{:?}", error))),
+    let result = parser::parse_ledger(input);
+    match result.finish() {
+        Ok((_, result)) => Ok(result),
+        Err(error) => Err(ParseError::String(convert_error(input, error))),
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,19 +21,17 @@ fn is_commodity_char(c: char) -> bool {
 }
 
 fn join_comments(inline_comment: Option<&str>, line_comments: Vec<&str>) -> Option<String> {
-    if let Some(ref inline) = inline_comment {
-        if line_comments.is_empty() {
-            inline_comment.map(|s| s.to_string())
-        } else {
-            let mut full = inline.to_string();
+    if let Some(inline) = inline_comment {
+        let mut full: String = inline.to_owned();
+        if !line_comments.is_empty() {
             full.push('\n');
             full.push_str(&line_comments.join("\n"));
-            Some(full)
         }
-    } else if line_comments.is_empty() {
-        None
-    } else {
+        Some(full)
+    } else if !line_comments.is_empty() {
         Some(line_comments.join("\n"))
+    } else {
+        None
     }
 }
 
@@ -93,11 +91,10 @@ fn parse_quantity(input: &str) -> LedgerParseResult<Decimal> {
                     many1(preceded(
                         tag(","),
                         take_while_m_n(3, 3, AsChar::is_dec_digit).map(str::to_owned),
-                    ))
-                    .map(|groups| groups.join("")),
+                    )),
                 )
-                .map(|(leading, rest)| format!("{}{}", leading, rest)),
-                digit0.map(|d: &str| d.to_string()),
+                .map(|(leading, rest)| format!("{}{}", leading, rest.join(""))),
+                digit0.map(str::to_owned),
             )),
             opt(recognize(preceded(tag("."), digit1))),
         ))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1041,45 +1041,15 @@ P 2017-11-12 12:00:00 mBH 5.00 PLN
         .unwrap()
         .1;
         assert_eq!(res.items.len(), 10);
-        assert!(match res.items[0] {
-            LedgerItem::LineComment(_) => true,
-            _ => false,
-        });
-        assert!(match res.items[1] {
-            LedgerItem::EmptyLine => true,
-            _ => false,
-        });
-        assert!(match res.items[2] {
-            LedgerItem::Include(_) => true,
-            _ => false,
-        });
-        assert!(match res.items[3] {
-            LedgerItem::EmptyLine => true,
-            _ => false,
-        });
-        assert!(match res.items[4] {
-            LedgerItem::CommodityPrice(_) => true,
-            _ => false,
-        });
-        assert!(match res.items[5] {
-            LedgerItem::EmptyLine => true,
-            _ => false,
-        });
-        assert!(match res.items[6] {
-            LedgerItem::LineComment(_) => true,
-            _ => false,
-        });
-        assert!(match res.items[7] {
-            LedgerItem::Transaction(_) => true,
-            _ => false,
-        });
-        assert!(match res.items[8] {
-            LedgerItem::EmptyLine => true,
-            _ => false,
-        });
-        assert!(match res.items[9] {
-            LedgerItem::Transaction(_) => true,
-            _ => false,
-        });
+        assert!(matches!(res.items[0], LedgerItem::LineComment(_)));
+        assert!(matches!(res.items[1], LedgerItem::EmptyLine));
+        assert!(matches!(res.items[2], LedgerItem::Include(_)));
+        assert!(matches!(res.items[3], LedgerItem::EmptyLine));
+        assert!(matches!(res.items[4], LedgerItem::CommodityPrice(_)));
+        assert!(matches!(res.items[5], LedgerItem::EmptyLine));
+        assert!(matches!(res.items[6], LedgerItem::LineComment(_)));
+        assert!(matches!(res.items[7], LedgerItem::Transaction(_)));
+        assert!(matches!(res.items[8], LedgerItem::EmptyLine));
+        assert!(matches!(res.items[9], LedgerItem::Transaction(_)));
     }
 }


### PR DESCRIPTION
No change to external API, some slight changes to what input it will accept relating to [hard separators](https://www.ledger-cli.org/3.0/doc/ledger3.html#Transaction-notes).

Parser no longer validates whether Transactions have more than one Posting without an Amount, I think this is better done in ledger-utils when calculating the missing amounts.