### PR TITLE
Serializer fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.1.0] - 2022-01-23
+
+- Make SerializerSettings fields public
+
 ## [5.0.0] - 2022-01-22
 
 - Implement posting commodity and lot prices

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger-parser"
-version = "5.0.0"
+version = "5.1.0"
 authors = ["Marek Gibek <marek-dev@yandex.com>"]
 description = "Rust library for parsing ledger cli (https://www.ledger-cli.org/) input files."
 license = "Unlicense"

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -3,8 +3,8 @@ use std::io;
 
 #[non_exhaustive]
 pub struct SerializerSettings {
-    indent: String,
-    eol: String,
+    pub indent: String,
+    pub eol: String,
 }
 
 impl SerializerSettings {


### PR DESCRIPTION
Need to make `SerializerSettings` struct fields public so I can use them in `ledger-utils`.