### PR TITLE
Fix no indent if only balance

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -141,8 +141,11 @@ impl Serializer for Posting {
             Reality::UnbalancedVirtual => write!(writer, "({})", self.account)?,
         }
 
-        if let Some(ref amount) = self.amount {
+        if self.amount.is_some() || self.balance.is_some() {
             write!(writer, "{}", settings.indent)?;
+        }
+
+        if let Some(ref amount) = self.amount {
             amount.write(writer, settings)?;
         }
 


### PR DESCRIPTION
If balanced is used, but not amount, no indent was added. This causes a parsing error when using `ledger-cli`. This ensures an indent is always added if either amount or balance is used.