### PR TITLE
feat: optional payee, custom date format, print tags, print posting comments on same line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+- Payees/descriptions are optional (improves Ledger compatiblity)
+- Support custom date formats during serialization
+- Support metadata tags during serialization
+- Support single-line posting comments at the of the posting line during serialization
+
 ## [6.0.0] - 2024-02-26
 
 - Support for dates and metadata tags in posting comments (thanks to Tim Bates)

--- a/src/model.rs
+++ b/src/model.rs
@@ -67,7 +67,7 @@ impl fmt::Display for LedgerItem {
 pub struct Transaction {
     pub status: Option<TransactionStatus>,
     pub code: Option<String>,
-    pub description: String,
+    pub description: Option<String>,
     pub comment: Option<String>,
     pub date: NaiveDate,
     pub effective_date: Option<NaiveDate>,
@@ -390,7 +390,7 @@ mod tests {
                 effective_date: Some(NaiveDate::from_ymd_opt(2018, 10, 14).unwrap()),
                 status: Some(TransactionStatus::Pending),
                 code: Some("123".to_owned()),
-                description: "Marek Ogarek".to_owned(),
+                description: Some("Marek Ogarek".to_owned()),
                 posting_metadata: PostingMetadata {
                     date: None,
                     effective_date: None,
@@ -467,7 +467,7 @@ mod tests {
                         effective_date: Some(NaiveDate::from_ymd_opt(2018, 10, 14).unwrap()),
                         status: Some(TransactionStatus::Pending),
                         code: Some("123".to_owned()),
-                        description: "Marek Ogarek".to_owned(),
+                        description: Some("Marek Ogarek".to_owned()),
                         posting_metadata: PostingMetadata {
                             date: None,
                             effective_date: None,
@@ -534,7 +534,7 @@ mod tests {
                         },
                         status: Some(TransactionStatus::Pending),
                         code: Some("123".to_owned()),
-                        description: "Marek Ogarek".to_owned(),
+                        description: Some("Marek Ogarek".to_owned()),
                         postings: vec![
                             Posting {
                                 account: "TEST:ABC 123".to_owned(),

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -94,8 +94,11 @@ impl Serializer for Transaction {
             write!(writer, " ({})", code)?;
         }
 
-        if !self.description.is_empty() {
-            write!(writer, " {}", self.description)?;
+        // for the None case, ledger would print "<Unspecified payee>"
+        if let Some(ref description) = self.description {
+            if !description.is_empty() {
+                write!(writer, " {}", description)?;
+            }
         }
 
         if let Some(ref comment) = self.comment {


### PR DESCRIPTION
Hi there. Thanks for this crate! I'm using it to build a rudimentary LSP for Ledger, which I'm using in turn to build a Ledger extension (with completions and formatting) for the Zed editor. This PR adds support for a few things that I encountered while working on that. It may be best to read this commit-by-commit, because there are several different changes in here:

- **Optional payee/description:** Ledger doesn't care if a transaction has a payee/description. I didn't know this until I found that this crate was failing to parse a file on which ledger was working fine. It doesn't come up very often, and I would be fine to back this out if you don't like it, but it seemed relevant in order to be more compatible with Ledger.
- **Custom date formats in the Serializer:** this is just me preferring to use strokes instead of dashes in dates (eg `2024/05/18` instead of `2024-05-18`) when printing/formatting my files. 😄 
- **Print metadata tags:** support for *parsing* metadata tags was added in v6, so this adds support in the default serializer to print these, too
- **Same line comments:** this is another preference of mine that I can back out if you'd prefer. Basically, I like having posting comments at the end of the line instead of on the next line. This adds a Serializer config to do so if the comment is not a multiline comment.

If this looks mergeable to you, I'm also happy to add the changes to bump the release to 6.1.0, if you'd like.

Thanks for your consideration!